### PR TITLE
docs: rewrite README with generic project instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,49 @@
-# Welcome to your Lovable project
+# Dwarven Forge Games
 
-## Project info
+A web application powered by [Vite](https://vitejs.dev/) and [React](https://react.dev/) written in
+TypeScript.
 
-**URL**: https://lovable.dev/projects/65429536-4611-44e9-82e0-280b6f9f6051
+## Prerequisites
 
-## How can I edit this code?
+- [Node.js](https://nodejs.org/) and npm
 
-There are several ways of editing your application.
+## Setup
 
-**Use Lovable**
+1. Clone the repository.
+2. Navigate to the project directory.
+3. Install dependencies:
 
-Simply visit the [Lovable Project](https://lovable.dev/projects/65429536-4611-44e9-82e0-280b6f9f6051) and start prompting.
+   ```sh
+   npm install
+   ```
 
-Changes made via Lovable will be committed automatically to this repo.
+## Development
 
-**Use your preferred IDE**
+- Start the development server with hot reloading:
 
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
+  ```sh
+  npm run dev
+  ```
 
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
+- Lint the codebase:
 
-Follow these steps:
+  ```sh
+  npm run lint
+  ```
 
-```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
+## Deployment
 
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
+1. Create an optimized production build:
 
-# Step 3: Install the necessary dependencies.
-npm i
+   ```sh
+   npm run build
+   ```
 
-# Step 4: Start the development server with auto-reloading and an instant preview.
-npm run dev
-```
+2. Preview the production build locally (optional):
 
-**Edit a file directly in GitHub**
+   ```sh
+   npm run preview
+   ```
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
+3. Deploy the contents of the `dist/` directory to your preferred hosting service.
 
-**Use GitHub Codespaces**
-
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
-
-## What technologies are used for this project?
-
-This project is built with:
-
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
-
-## How can I deploy this project?
-
-Simply open [Lovable](https://lovable.dev/projects/65429536-4611-44e9-82e0-280b6f9f6051) and click on Share -> Publish.
-
-## Can I connect a custom domain to my Lovable project?
-
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)


### PR DESCRIPTION
## Summary
- remove Lovable-specific README content
- document generic setup, development, and deployment steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint found errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f91ede99483218cb8517653a5edc1